### PR TITLE
Moving introduction vignette to homepage

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,9 +15,11 @@ makedocs(
     format = Documenter.HTML(),
     modules = [SpatialBoundaries],
     pages = [
-        "Home" => "index.md",
-        "Vignettes" => [
+        "Home" => [
             "Introduction" => "vignettes/introduction.md",
+            "SpatialBoundaries.jl" => "index.md"
+            ],
+        "Vignettes" => [
             "Finding boundaries" => "vignettes/boundaries.md",
             "Triangulation wombling" => "vignettes/triangulation.md",
             "SDM Layers" => "vignettes/simplesdmlayers.md"


### PR DESCRIPTION
Should close issue #39 by moving what is currently the introduction vignette to the home/landing page of SpatialBoundaries.jl

**Type of change**   

- [ x] :book: Documentation change

**Checklist**

- [ ] The changes are documented
  - [ ] The docstrings of the different functions describe the arguments, purpose, and behavior 
  - [ ] There are examples in the documentation website
- [ ] The changes are tested
- [ ] The changes **do not** modify the behavior of the previously existing functions
  - If they **do**, please explain why and how in the introduction paragraph
- [ ] For **new contributors** - my name and information are added to `.zenodo.json`
- [ ] The `Project.toml` field `version` has been updated
  - Change the *last* number for a `v0.0.x` series release, a bug fix, or a performance improvement
  - Change the *middle* number for additional features that *do not* break the current test suite (unless you fix a bug in the test suite)
  - Change the *first* number for changes that break the current test suite
