### PR TITLE
Boundaries using ecdf

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpatialBoundaries"
 uuid = "8d2ba62a-3d23-4a2b-b692-6b63e9267be2"
 authors = ["Tanya Strydom <tanya.strydom@umontreal.ca>", "Timothée Poisot <timothee.poisot@umontreal.ca>"]
-version = "0.0.1"
+version = "0.0.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/src/vignettes/boundaries.jl
+++ b/docs/src/vignettes/boundaries.jl
@@ -33,7 +33,7 @@ heatmap(W.m; c=:nuuk)
 # effect of this threshold is would be a good idea:
 
 thresholds = LinRange(0.0, 0.2, 200)
-patches = [length(boundaries(W; threshold=t)) for t in thresholds]
+patches = [length(boundaries(W, t)) for t in thresholds]
 
 plot(thresholds, log1p.(patches), aspectratio=:none)
 xaxis!("Threshold", (0., 0.2))
@@ -49,7 +49,7 @@ yaxis!("log(boundary patches + 1)", (0., 9.))
 b = similar(W.m)
 
 for t in reverse(LinRange(0.0, 1.0, 200))
-    b[boundaries(W; threshold=t)] .= t
+    b[boundaries(W, t)] .= t
 end
 
 heatmap(b, c=:tofino, clim=(0,1))
@@ -57,7 +57,7 @@ heatmap(b, c=:tofino, clim=(0,1))
 # This also suggests that we will get well delineated patches for low values of
 # the threshold.
 
-B = boundaries(W; threshold=0.01);
+B = boundaries(W, 0.01);
 
 # In the following figure, cells identified as candidate boundaries are marked
 # in white:

--- a/src/SpatialBoundaries.jl
+++ b/src/SpatialBoundaries.jl
@@ -8,7 +8,6 @@ using StatsBase
 using Requires
 
 include(joinpath("types", "Womble.jl"))
-include(joinpath("types", "overloads.jl"))
 export Womble, TriangulationWomble, LatticeWomble
 
 include(joinpath("lib", "rateofchange.jl"))

--- a/src/lib/boundaries.jl
+++ b/src/lib/boundaries.jl
@@ -1,3 +1,9 @@
+function _quantizer(x)
+    v = filter(!isnan, x)
+    return StatsBase.ecdf(v)
+    # TODO what's up with 0?
+end
+
 """
     boundaries(W::TriangulationWomble{T}; threshold::T=0.1) where {T <: Number}
 

--- a/src/lib/boundaries.jl
+++ b/src/lib/boundaries.jl
@@ -1,38 +1,25 @@
-function _quantizer(x)
-    v = filter(!isnan, x)
-    return StatsBase.ecdf(v)
-    # TODO what's up with 0?
-end
-
 """
-    boundaries(W::TriangulationWomble{T}; threshold::T=0.1) where {T <: Number}
+    boundaries(W::Womble, t=0.1; ignorezero=false)
 
-Extracts candidate boundaries using calculated rates of change (M) on specified
-threshold. Default threshold is 10%, meaning that the top 10% of pixels are
+Extracts candidate boundaries using calculated wombling object `W` on specified
+threshold `t`. Default threshold is 0.1, meaning that the top 10% of pixels are
 selected as part of the boundaries. This function returns a list of indices
 identifying which simplices are part of the boundaries. The NaN values in the
-rates of change are not going to be a part of the boundaries.
+rates of change are not going to be a part of the boundaries. The keyword
+`ignorezero`, which defaults to `false`, can be used to remove the points with
+a rate of change of 0.
 """
-function boundaries(W::TriangulationWomble{T}; threshold::T=0.1) where {T<:Number}
-    @assert 0.0 < threshold <= 1.0
-    limit = floor(Int, length(W.m) * threshold)
-    nans = count(isnan, W.m)
-    return findall(nans .< denserank(W; rev=true) .<= (limit+nans))
-end
-
-"""
-    boundaries(W::LatticeWomble{T}; threshold::T=0.1) where {T<:Number}
-
-Extracts candidate boundaries using calculated rates of change (M) on specified
-threshold. Default threshold is 10%, meaning that the top 10% of pixels are
-selected as part of the boundaries. This function returns an array of Cartesian
-indices corresponding to the rate of change matrix, indicating which positions
-are part of the boundaries. The NaN values in the rates of change are not going
-to be a part of the boundaries.
-"""
-function boundaries(W::LatticeWomble{T}; threshold::T=0.1) where {T<:Number}
-    @assert 0.0 < threshold <= 1.0
-    limit = floor(Int, size(W.m, 2) * size(W.m, 1) * threshold)
-    nans = count(isnan, W.m)
-    return findall(nans .< denserank(W; rev=true) .<= (limit+nans))
+function boundaries(W::T, t=0.1; ignorezero=false) where {T <: Womble}
+    #The threshold must be in ]0,1]
+    @assert 0.0 < t <= 1.0
+    # Remove the NaN values from the rate object
+    v = filter(!isnan, W.m)
+    # The zeros get removed IFF we require it
+    if ignorezero
+        filter!(iszero, v)
+    end
+    # This is the quantile function
+    qf = StatsBase.ecdf(v)
+    # We return the positions for which quantile is larger than 1 minus the threshold
+    return findall(x -> x > (1.0 - t), qf.(W.m))
 end

--- a/src/lib/boundaries.jl
+++ b/src/lib/boundaries.jl
@@ -16,7 +16,7 @@ function boundaries(W::T, t=0.1; ignorezero=false) where {T <: Womble}
     v = filter(!isnan, W.m)
     # The zeros get removed IFF we require it
     if ignorezero
-        filter!(iszero, v)
+        filter!(!iszero, v)
     end
     # This is the quantile function
     qf = StatsBase.ecdf(v)

--- a/src/lib/boundaries.jl
+++ b/src/lib/boundaries.jl
@@ -8,6 +8,7 @@ identifying which simplices are part of the boundaries. The NaN values in the
 rates of change are not going to be a part of the boundaries.
 """
 function boundaries(W::TriangulationWomble{T}; threshold::T=0.1) where {T<:Number}
+    @assert 0.0 < threshold <= 1.0
     limit = floor(Int, length(W.m) * threshold)
     nans = count(isnan, W.m)
     return findall(nans .< denserank(W; rev=true) .<= (limit+nans))
@@ -24,6 +25,7 @@ are part of the boundaries. The NaN values in the rates of change are not going
 to be a part of the boundaries.
 """
 function boundaries(W::LatticeWomble{T}; threshold::T=0.1) where {T<:Number}
+    @assert 0.0 < threshold <= 1.0
     limit = floor(Int, size(W.m, 2) * size(W.m, 1) * threshold)
     nans = count(isnan, W.m)
     return findall(nans .< denserank(W; rev=true) .<= (limit+nans))

--- a/src/types/overloads.jl
+++ b/src/types/overloads.jl
@@ -1,3 +1,0 @@
-function StatsBase.denserank(W::T; kw...) where {T <: Womble}
-    return StatsBase.denserank(W.m; kw...)
-end

--- a/test/units/02_boundaries.jl
+++ b/test/units/02_boundaries.jl
@@ -22,4 +22,10 @@ W = wombling(A)
 B = boundaries(W)
 @test !any(map(isnan, W.m[B]))
 
+A = zeros(Float64, 101, 101)
+A[1:51, 1:51] = rand(Float64, 51, 51)
+W = wombling(A)
+B = boundaries(W, 0.1; ignorezero=true)
+@test length(B) == ceil(Int64, 51*51*0.1)
+
 end

--- a/test/units/02_boundaries.jl
+++ b/test/units/02_boundaries.jl
@@ -10,11 +10,10 @@ W = wombling(A)
 B = boundaries(W)
 @test length(B) == prod(size(A).-1)
 
-A[4, 8] = 5.0
-A[5, 8] = 5.0
+A = rand(Float64, 101, 101)
 W = wombling(A)
-B = boundaries(W; threshold=0.03)
-@test length(B) == 5
+B = boundaries(W, 0.2)
+@test length(B) == 0.2*prod(size(W.m))
 
 A = rand(Float64, 10, 10)
 n = rand(eachindex(A), 10)


### PR DESCRIPTION
This version uses `StatsBase.ecdf` to get the boundaries, which works a bit better than `denserank`